### PR TITLE
Add PDF↔XML report support

### DIFF
--- a/pkg/report_builder_pdf_xml.py
+++ b/pkg/report_builder_pdf_xml.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, List
+
+from .crc import compute_crc32
+
+def _tri(v: bool | None) -> str:
+    return "Да" if v is True else "Нет" if v is False else "—"
+
+def build_report_pdf_xml(xml_map: Dict[str, dict], pdf_files: List[Path], case_sensitive: bool = True) -> List[Dict]:
+    """Сравнение XML↔PDF:
+      - Имя (строгое сравнение)
+      - CRC-32
+    Сценарии:
+      - PDF есть, записи в XML нет → ERROR_PDF_EXTRA
+      - Запись в XML есть, PDF не найден → ERROR_XML_EXTRA
+      - CRC разные → CRC_MISMATCH
+      - Есть совпадение по CRC, но имя отличается → NAME_MISMATCH (в одну строку)
+      - Всё ок → OK
+    """
+    rows: List[Dict] = []
+    used_xml = set()
+
+    # Индекс: CRC из XML -> список имён
+    xml_crc_index: Dict[str, List[str]] = {}
+    for name, meta in xml_map.items():
+        crc = (meta.get("crc_hex") or "").upper()
+        if crc:
+            xml_crc_index.setdefault(crc, []).append(name)
+
+    for f in pdf_files:
+        base = f.name
+        key = base if case_sensitive else base.lower()
+        meta = xml_map.get(key)
+        actual_crc_hex = f"{compute_crc32(f):08X}"
+
+        name_match = None
+        crc_match = None
+        status: List[str] = []
+        details: List[str] = []
+
+        if meta is None:
+            # пытаемся сопоставить по CRC
+            hits = xml_crc_index.get(actual_crc_hex, [])
+            if len(hits) == 1:
+                xml_name = hits[0]
+                used_xml.add(xml_name if case_sensitive else xml_name.lower())
+                name_match = (xml_name == base)
+                if not name_match:
+                    status.append("NAME_MISMATCH")
+                    details.append("Сопоставлено по CRC-32, имя различается")
+                crc_match = True
+            elif len(hits) > 1:
+                status.append("ERROR_PDF_EXTRA")
+                details.append(f"Найдено несколько записей в XML с тем же CRC ({actual_crc_hex})")
+            else:
+                status.append("ERROR_PDF_EXTRA")
+                details.append("Файл есть, но отсутствует запись в XML")
+        else:
+            used_xml.add(key)
+            name_match = True
+            xml_crc = (meta.get("crc_hex") or "").upper() or None
+            if xml_crc:
+                crc_match = (xml_crc == actual_crc_hex)
+                if not crc_match:
+                    status.append("CRC_MISMATCH")
+                    details.append(f"CRC-32 не совпадает: XML={xml_crc}, PDF={actual_crc_hex}")
+            else:
+                details.append("В XML отсутствует CRC-32")
+
+        if not status and name_match is True and (crc_match is True or crc_match is None):
+            status.append("OK")
+
+        rows.append({
+            "Имя файла": base,
+            "Файл из XML": (base if meta else (hits[0] if 'hits' in locals() and hits else None)),
+            "CRC-32 XML": ((meta.get('crc_hex') or '').upper() if meta else None),
+            "CRC-32 PDF": actual_crc_hex,
+            "Имя совпадает": _tri(name_match),
+            "CRC совпадает": _tri(crc_match),
+            "Статус": ";".join(status) if status else "—",
+            "Подробности": "; ".join(details) if details else None,
+        })
+
+    # Лишние записи в XML
+    for name, meta in xml_map.items():
+        k = name if case_sensitive else name.lower()
+        if k in used_xml:
+            continue
+        rows.append({
+            "Имя файла": None,
+            "Файл из XML": name,
+            "CRC-32 XML": (meta.get("crc_hex") or "").upper() or None,
+            "CRC-32 PDF": None,
+            "Имя совпадает": "—",
+            "CRC совпадает": "—",
+            "Статус": "ERROR_XML_EXTRA",
+            "Подробности": "Запись в XML есть, соответствующий файл не найден",
+        })
+
+    return rows

--- a/pkg/xlsx_writer_pdf_xml.py
+++ b/pkg/xlsx_writer_pdf_xml.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+from pathlib import Path
+from typing import List, Dict
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill, Border, Side
+from openpyxl.utils import get_column_letter
+from openpyxl.formatting.rule import CellIsRule
+
+GREEN = PatternFill(start_color="E7F7E7", end_color="E7F7E7", fill_type="solid")
+RED = PatternFill(start_color="FFE5E5", end_color="FFE5E5", fill_type="solid")
+GRAY = PatternFill(start_color="F2F2F2", end_color="F2F2F2", fill_type="solid")
+
+HEADERS = [
+    "Имя файла",
+    "Файл из XML",
+    "CRC-32 XML",
+    "CRC-32 PDF",
+    "Имя совпадает",
+    "CRC совпадает",
+    "Статус",
+    "Подробности",
+]
+
+def _autosize(ws):
+    max_width = {}
+    for row in ws.iter_rows(values_only=True):
+        for idx, val in enumerate(row, start=1):
+            s = "" if val is None else str(val)
+            width = max(3, min(120, int(len(s) * 1.1) + 2))
+            if idx not in max_width or width > max_width[idx]:
+                max_width[idx] = width
+    for idx, w in max_width.items():
+        ws.column_dimensions[get_column_letter(idx)].width = w
+
+def _borders(ws):
+    thin = Side(border_style="thin", color="D0D0D0")
+    border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in ws.iter_rows(min_row=1, max_row=ws.max_row, min_col=1, max_col=ws.max_column):
+        for cell in row:
+            cell.border = border
+
+def _style(ws):
+    for c in ws[1]:
+        c.font = Font(bold=True)
+        c.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+        c.fill = GRAY
+
+    left_cols = (1,2,7,8)
+    for row in ws.iter_rows(min_row=2):
+        for cell in row:
+            if cell.column in left_cols:
+                cell.alignment = Alignment(horizontal="left", vertical="top", wrap_text=True)
+            else:
+                cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+
+    ws.auto_filter.ref = ws.dimensions
+    ws.freeze_panes = "A2"
+
+    for col in ("E","F"):
+        ws.conditional_formatting.add(f"{col}2:{col}{ws.max_row}", CellIsRule(operator='equal', formula=['"Да"'], fill=GREEN))
+        ws.conditional_formatting.add(f"{col}2:{col}{ws.max_row}", CellIsRule(operator='equal', formula=['"Нет"'], fill=RED))
+
+    ws.conditional_formatting.add(f"G2:G{ws.max_row}", CellIsRule(operator='equal', formula=['"OK"'], fill=GREEN))
+    ws.conditional_formatting.add(f"G2:G{ws.max_row}", CellIsRule(operator='notEqual', formula=['"OK"'], fill=RED))
+
+def write_xlsx_pdf_xml(rows: List[Dict], out_path: Path) -> tuple[int, dict]:
+    wb = Workbook()
+    ws = wb.active; ws.title = "PDF/XML Report"
+
+    ws.append(HEADERS)
+    for r in rows:
+        ws.append([
+            r.get("Имя файла"),
+            r.get("Файл из XML"),
+            r.get("CRC-32 XML"),
+            r.get("CRC-32 PDF"),
+            r.get("Имя совпадает"),
+            r.get("CRC совпадает"),
+            r.get("Статус"),
+            r.get("Подробности"),
+        ])
+
+    _style(ws)
+    _autosize(ws)
+    _borders(ws)
+
+    sm = wb.create_sheet("Summary")
+    total = len(rows)
+    ok = sum(1 for r in rows if r["Статус"] == "OK")
+    errors = total - ok
+    sm.append(["Метрика", "Значение"])
+    sm.append(["Всего строк", total])
+    sm.append(["OK", ok])
+    sm.append(["Ошибки (все не-OK)", errors])
+    sm.auto_filter.ref = sm.dimensions
+    sm.freeze_panes = "A2"
+    for c in sm[1]:
+        c.font = Font(bold=True)
+        c.alignment = Alignment(horizontal="center", vertical="center")
+        c.fill = GRAY
+    # автоширина и рамки у Summary
+    maxw = {}
+    for row in sm.iter_rows(values_only=True):
+        for idx, val in enumerate(row, start=1):
+            s = "" if val is None else str(val)
+            w = max(3, min(80, int(len(s)*1.1)+2))
+            if idx not in maxw or w>maxw[idx]:
+                maxw[idx]=w
+    for idx, w in maxw.items():
+        sm.column_dimensions[get_column_letter(idx)].width = w
+    thin = Side(border_style="thin", color="D0D0D0")
+    border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in sm.iter_rows(min_row=1, max_row=sm.max_row, min_col=1, max_col=sm.max_column):
+        for cell in row:
+            cell.border = border
+
+    wb.save(out_path)
+    exit_code = 0 if errors==0 else 1
+    return exit_code, {"total": total, "ok": ok, "errors": errors}


### PR DESCRIPTION
## Summary
- add builder for checking PDF files against XML entries by name and CRC
- expose CLI/GUI options to run PDF↔XML check and output `pdf_xml_report.xlsx`
- provide XLSX writer for new PDF↔XML report

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c4774f5450832fa4136ec0b6be61b3