### PR TITLE
Add recommendations to report output and Excel

### DIFF
--- a/pkg/report_builder.py
+++ b/pkg/report_builder.py
@@ -4,8 +4,22 @@ from pathlib import Path
 from typing import Dict, List
 from .crc import compute_crc32
 
+
+RECOMMENDATIONS = {
+    "OK": "Действий не требуется",
+    "ERROR_IFC_EXTRA": "Удалите лишний файл или добавьте запись в XML",
+    "ERROR_XML_EXTRA": "Удалите лишнюю запись из XML или добавьте соответствующий файл IFC",
+    "CRC_MISMATCH": "Проверьте корректность файлов и пересоздайте CRC",
+    "NAME_MISMATCH": "Переименуйте файл или исправьте запись в XML",
+}
+
 def _tri(v: bool | None) -> str:
     return "Да" if v is True else "Нет" if v is False else "—"
+
+
+def _recommendation(status: List[str]) -> str | None:
+    recs = [RECOMMENDATIONS.get(s) for s in status if RECOMMENDATIONS.get(s)]
+    return "; ".join(recs) if recs else None
 
 def build_report(xml_map: Dict[str, dict], ifc_files: List[Path], case_sensitive: bool=True) -> List[Dict]:
     """
@@ -81,6 +95,7 @@ def build_report(xml_map: Dict[str, dict], ifc_files: List[Path], case_sensitive
             "CRC совпадает": _tri(crc_match),
             "Статус": ";".join(status) if status else "—",
             "Подробности": "; ".join(details) if details else None,
+            "recommendation": _recommendation(status),
         })
 
     # Лишние записи в XML
@@ -97,6 +112,7 @@ def build_report(xml_map: Dict[str, dict], ifc_files: List[Path], case_sensitive
             "CRC совпадает": "—",
             "Статус": "ERROR_XML_EXTRA",
             "Подробности": "Запись в XML есть, соответствующий файл не найден",
+            "recommendation": RECOMMENDATIONS.get("ERROR_XML_EXTRA"),
         })
 
     return rows

--- a/pkg/report_builder_iul.py
+++ b/pkg/report_builder_iul.py
@@ -6,8 +6,25 @@ import time
 from .crc import compute_crc32
 from .iul_reader import IulEntry, pdf_name_ok_lenient, pdf_name_ok_strict
 
+
+RECOMMENDATIONS = {
+    "OK": "Действий не требуется",
+    "ERROR_IFC_EXTRA": "Удалите лишний файл или добавьте запись в ИУЛ",
+    "ERROR_IUL_EXTRA": "Удалите лишнюю запись из ИУЛ или добавьте соответствующий файл",
+    "CRC_MISMATCH": "Проверьте корректность файлов и пересоздайте CRC",
+    "NAME_MISMATCH": "Переименуйте файл или обновите запись в ИУЛ",
+    "SIZE_MISMATCH": "Проверьте размер файла и обновите информацию в ИУЛ",
+    "DT_MISMATCH": "Обновите дату/время в ИУЛ или замените файл",
+    "PDF_NAME_MISMATCH": "Переименуйте PDF согласно требуемому правилу",
+}
+
 def _tri(v: bool | None) -> str:
     return "Да" if v is True else "Нет" if v is False else "—"
+
+
+def _recommendation(status: List[str]) -> str | None:
+    recs = [RECOMMENDATIONS.get(s) for s in status if RECOMMENDATIONS.get(s)]
+    return "; ".join(recs) if recs else None
 
 def _fmt_mtime(ts: float) -> str:
     t = time.localtime(ts)
@@ -108,6 +125,7 @@ def build_report_iul(iul_map: Dict[str, IulEntry], ifc_files: List[Path], strict
             "Имя PDF соответствует правилу": _tri(pdf_name_ok),
             "Статус": ";".join(status) if status else "—",
             "Подробности": "; ".join(details) if details else None,
+            "recommendation": _recommendation(status),
         })
 
     for k, e in iul_map.items():
@@ -130,5 +148,6 @@ def build_report_iul(iul_map: Dict[str, IulEntry], ifc_files: List[Path], strict
             "Имя PDF соответствует правилу": "—",
             "Статус": "ERROR_IUL_EXTRA",
             "Подробности": "Запись в ИУЛ есть, соответствующий файл не найден",
+            "recommendation": RECOMMENDATIONS.get("ERROR_IUL_EXTRA"),
         })
     return rows

--- a/pkg/xlsx_writer.py
+++ b/pkg/xlsx_writer.py
@@ -21,6 +21,7 @@ HEADERS = [
     "CRC совпадает",
     "Статус",
     "Подробности",
+    "Рекомендации",
 ]
 
 def _autosize(ws):
@@ -47,7 +48,7 @@ def _style(ws):
         c.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
         c.fill = GRAY
 
-    left_cols = (1,2,7,8)
+    left_cols = (1,2,7,8,9)
     for row in ws.iter_rows(min_row=2):
         for cell in row:
             if cell.column in left_cols:
@@ -80,6 +81,7 @@ def write_xlsx(rows: List[Dict], out_path: Path) -> tuple[int, dict]:
             r.get("CRC совпадает"),
             r.get("Статус"),
             r.get("Подробности"),
+            r.get("recommendation"),
         ])
 
     _style(ws)

--- a/pkg/xlsx_writer_iul.py
+++ b/pkg/xlsx_writer_iul.py
@@ -29,6 +29,7 @@ HEADERS = [
     "Имя PDF соответствует правилу",
     "Статус",
     "Подробности",
+    "Рекомендации",
 ]
 
 def _autosize(ws):
@@ -55,7 +56,7 @@ def _style(ws):
         c.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
         c.fill = GRAY
 
-    left_cols = (1,2,3,6,7,16)
+    left_cols = (1,2,3,6,7,16,17)
     for row in ws.iter_rows(min_row=2):
         for cell in row:
             if cell.column in left_cols:
@@ -96,6 +97,7 @@ def write_xlsx_iul(rows: List[Dict], out_path: Path) -> tuple[int, dict]:
             r.get("Имя PDF соответствует правилу"),
             r.get("Статус"),
             r.get("Подробности"),
+            r.get("recommendation"),
         ])
 
     _style(ws)


### PR DESCRIPTION
## Summary
- include status-based recommendations in report builders
- write recommendations into new column in generated Excel reports

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4777abd38832fbb437b6892f1527c