### PR TITLE
Add tests and pytest configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+pytest_cache/

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pymupdf>=1.23.8
 pytesseract>=0.3.10
 Pillow>=10.2.0
 PyYAML>=6.0.1
+
+pytest>=8.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))

--- a/tests/test_crc.py
+++ b/tests/test_crc.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import zlib
+from xmlchecks.pkg.crc import compute_crc32
+
+def test_compute_crc32(tmp_path):
+    p = tmp_path / 'data.bin'
+    data = b'hello world'
+    p.write_bytes(data)
+    expected = zlib.crc32(data) & 0xFFFFFFFF
+    assert compute_crc32(p) == expected

--- a/tests/test_iul_reader.py
+++ b/tests/test_iul_reader.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from xmlchecks.pkg.iul_reader import extract_iul_entries_from_pdf
+
+def test_extract_iul_entries_from_pdf(monkeypatch, tmp_path):
+    pdf_path = tmp_path / 'doc.pdf'
+    pdf_path.write_bytes(b'%PDF-1.4')
+    sample_text = 'CRC-32 ABCDEF12\nfile1.ifc 01.02.2024 12:34 1234'
+    monkeypatch.setattr('xmlchecks.pkg.iul_reader._extract_text_pypdf2', lambda p: sample_text)
+    monkeypatch.setattr('xmlchecks.pkg.iul_reader._extract_text_ocr', lambda p: '')
+    entries = extract_iul_entries_from_pdf(pdf_path)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.basename == 'file1.ifc'
+    assert e.crc_hex == 'ABCDEF12'
+    assert e.dt_str == '01.02.2024 12:34'
+    assert e.size_bytes == 1234
+    assert e.source_pdf == pdf_path.name

--- a/tests/test_report_builder.py
+++ b/tests/test_report_builder.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from xmlchecks.pkg.report_builder import build_report
+from xmlchecks.pkg.crc import compute_crc32
+
+
+def create_file(dir, name, content):
+    p = dir / name
+    p.write_text(content)
+    return p
+
+
+def test_build_report_scenarios(tmp_path):
+    good = create_file(tmp_path, 'good.ifc', 'good')
+    badcrc = create_file(tmp_path, 'badcrc.ifc', 'bad')
+    name_mismatch = create_file(tmp_path, 'name_mismatch.ifc', 'same')
+    extra = create_file(tmp_path, 'extra.ifc', 'extra')
+
+    crc_good = f"{compute_crc32(good):08X}"
+    crc_name = f"{compute_crc32(name_mismatch):08X}"
+
+    xml_map = {
+        'good.ifc': {'crc_hex': crc_good},
+        'badcrc.ifc': {'crc_hex': '00000000'},
+        'other.ifc': {'crc_hex': crc_name},
+        'missing.ifc': {'crc_hex': '12345678'},
+    }
+
+    rows = build_report(xml_map, [good, badcrc, name_mismatch, extra])
+    status = {row['Имя файла'] or row['Файл из XML']: row['Статус'] for row in rows}
+
+    assert status['good.ifc'] == 'OK'
+    assert status['badcrc.ifc'] == 'CRC_MISMATCH'
+    assert status['name_mismatch.ifc'] == 'NAME_MISMATCH'
+    assert status['extra.ifc'] == 'ERROR_IFC_EXTRA'
+    assert status['missing.ifc'] == 'ERROR_XML_EXTRA'

--- a/tests/test_report_builder_iul.py
+++ b/tests/test_report_builder_iul.py
@@ -1,0 +1,54 @@
+import os
+from xmlchecks.pkg.report_builder_iul import build_report_iul, _fmt_mtime
+from xmlchecks.pkg.crc import compute_crc32
+from xmlchecks.pkg.iul_reader import IulEntry
+
+
+def create_file(dir, name, content, mtime):
+    p = dir / name
+    p.write_text(content)
+    os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_build_report_iul_scenarios(tmp_path):
+    base = 1700000000  # fixed timestamp
+    good = create_file(tmp_path, 'good.ifc', 'good', base)
+    crc_bad = create_file(tmp_path, 'crc_bad.ifc', 'crc', base + 1)
+    size_bad = create_file(tmp_path, 'size_bad.ifc', 'size', base + 2)
+    dt_bad = create_file(tmp_path, 'dt_bad.ifc', 'dt', base + 3)
+    pdf_bad = create_file(tmp_path, 'pdf_bad.ifc', 'pdf', base + 4)
+    name_mismatch_file = create_file(tmp_path, 'name_mismatch.ifc', 'same', base + 5)
+    extra = create_file(tmp_path, 'extra.ifc', 'extra', base + 6)
+
+    def info(p):
+        return f"{compute_crc32(p):08X}", _fmt_mtime(p.stat().st_mtime), p.stat().st_size
+
+    crc_good, dt_good, size_good = info(good)
+    crc_crc_bad, dt_crc, size_crc = info(crc_bad)
+    crc_size, dt_size, size_size = info(size_bad)
+    crc_dt, dt_dt, size_dt = info(dt_bad)
+    crc_pdf, dt_pdf, size_pdf = info(pdf_bad)
+    crc_name, dt_name, size_name = info(name_mismatch_file)
+
+    iul_map = {
+        'good.ifc': IulEntry('good.ifc', crc_good, dt_good, size_good, 'ctx', 'goodИУЛ.pdf'),
+        'crc_bad.ifc': IulEntry('crc_bad.ifc', 'FFFFFFFF', dt_crc, size_crc, 'ctx', 'crc_badИУЛ.pdf'),
+        'size_bad.ifc': IulEntry('size_bad.ifc', crc_size, dt_size, size_size + 1, 'ctx', 'size_badИУЛ.pdf'),
+        'dt_bad.ifc': IulEntry('dt_bad.ifc', crc_dt, '01.01.2000 00:00', size_dt, 'ctx', 'dt_badИУЛ.pdf'),
+        'pdf_bad.ifc': IulEntry('pdf_bad.ifc', crc_pdf, dt_pdf, size_pdf, 'ctx', 'pdf_bad.pdf'),
+        'other.ifc': IulEntry('other.ifc', crc_name, dt_name, size_name, 'ctx', 'name_mismatchИУЛ.pdf'),
+        'missing.ifc': IulEntry('missing.ifc', 'ABCDEF12', '01.01.2024 00:00', 123, 'ctx', 'missingИУЛ.pdf'),
+    }
+
+    rows = build_report_iul(iul_map, [good, crc_bad, size_bad, dt_bad, pdf_bad, name_mismatch_file, extra])
+    status = {row['Имя файла'] or row['Файл из ИУЛ']: row['Статус'] for row in rows}
+
+    assert status['good.ifc'] == 'OK'
+    assert status['crc_bad.ifc'] == 'CRC_MISMATCH'
+    assert status['size_bad.ifc'] == 'SIZE_MISMATCH'
+    assert status['dt_bad.ifc'] == 'DT_MISMATCH'
+    assert status['pdf_bad.ifc'] == 'PDF_NAME_MISMATCH'
+    assert status['name_mismatch.ifc'] == 'NAME_MISMATCH'
+    assert status['extra.ifc'] == 'ERROR_IFC_EXTRA'
+    assert status['missing.ifc'] == 'ERROR_IUL_EXTRA'

--- a/tests/test_xml_reader.py
+++ b/tests/test_xml_reader.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from xmlchecks.pkg.xml_reader import extract_from_xml, DEFAULT_RULES
+
+def test_extract_from_xml(tmp_path):
+    xml_content = '''<?xml version="1.0"?>\n<Root>\n  <ModelFile>\n    <FileName>file1.ifc</FileName>\n    <FileChecksum>ABCDEF12</FileChecksum>\n    <FileFormat>IFC</FileFormat>\n  </ModelFile>\n</Root>'''
+    xml_path = tmp_path / 'data.xml'
+    xml_path.write_text(xml_content, encoding='utf-8')
+    res = extract_from_xml(xml_path, DEFAULT_RULES)
+    assert res == {'file1.ifc': {'crc_hex': 'ABCDEF12', 'format': 'IFC'}}


### PR DESCRIPTION
## Summary
- add pytest dependency
- cover crc, xml, iul parsers and report builders with tests for all scenarios

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4777f76c0832fac9e060ac67e2f7a