### PR TITLE
Handle SignFile PDF entries in XML parser

### DIFF
--- a/main_cli.py
+++ b/main_cli.py
@@ -59,10 +59,10 @@ def main():
         if out_xml.exists() and not args.force:
             logging.error("Файл отчёта (XML) уже существует: %s. Запустите с --force для перезаписи.", out_xml); return 2
         rules = read_rules(Path(__file__).with_name("rules.yaml"))
-        xml_map = extract_from_xml(args.xml, rules, case_sensitive=True)
+        xml_map, xml_pdf = extract_from_xml(args.xml, rules, case_sensitive=True)
         rows_xml = build_report(xml_map, ifc_files, case_sensitive=True)
         exit_xml, stats_xml = write_xlsx(rows_xml, out_xml)
-        logging.info("Готово (XML). Отчёт: %s | Итоги: %s", out_xml, stats_xml)
+        logging.info("Готово (XML). Отчёт: %s | Итоги: %s | Подписей PDF: %s", out_xml, stats_xml, len(xml_pdf))
 
     # IUL
     if args.check_iul:

--- a/main_gui.py
+++ b/main_gui.py
@@ -255,8 +255,8 @@ class App(tk.Tk):
                     else:
                         self._log(f"{EMOJI['xml']} Чтение XML...")
                         rules = read_rules(Path(__file__).with_name("rules.yaml"))
-                        xml_map = extract_from_xml(xml, rules, case_sensitive=True)
-                        self._log(f"    Записей IFC в XML: {len(xml_map)}")
+                        xml_map, xml_pdf = extract_from_xml(xml, rules, case_sensitive=True)
+                        self._log(f"    Записей IFC в XML: {len(xml_map)} | Подписей PDF: {len(xml_pdf)}")
 
                         self._log(f"{EMOJI['search']} Сверка по XML...")
                         rows_xml = build_report(xml_map, files_ifc, case_sensitive=True)

--- a/pkg/xml_reader.py
+++ b/pkg/xml_reader.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Tuple
 import xml.etree.ElementTree as ET
 
 try:
@@ -14,7 +14,7 @@ DEFAULT_RULES = {
     "name_tag": "FileName",
     "checksum_tag": "FileChecksum",
     "format_tag": "FileFormat",
-    "filter_format": "IFC",
+    "filter_format": ["IFC", "PDF"],
 }
 
 def read_rules(path: Path) -> Dict[str, Any]:
@@ -43,7 +43,7 @@ def _find_child_text(elem: ET.Element, wanted: str) -> Optional[str]:
             return txt if txt else None
     return None
 
-def extract_from_xml(xml_path: Path, rules: Dict[str, Any], case_sensitive: bool=True) -> Dict[str, Dict[str, Any]]:
+def extract_from_xml(xml_path: Path, rules: Dict[str, Any], case_sensitive: bool=True) -> Tuple[Dict[str, Dict[str, Any]], List[Dict[str, Any]]]:
     if not xml_path.exists():
         raise FileNotFoundError(f"XML не найден: {xml_path}")
     tree = ET.parse(str(xml_path))
@@ -54,9 +54,17 @@ def extract_from_xml(xml_path: Path, rules: Dict[str, Any], case_sensitive: bool
     checksum_tag = (rules.get("checksum_tag") or DEFAULT_RULES["checksum_tag"])
     format_tag = (rules.get("format_tag") or DEFAULT_RULES["format_tag"])
     filter_format = rules.get("filter_format", DEFAULT_RULES["filter_format"])
+    if isinstance(filter_format, str):
+        filter_set = {filter_format.strip().upper()} if filter_format else set()
+    else:
+        try:
+            filter_set = {str(x).strip().upper() for x in filter_format if x}
+        except Exception:
+            filter_set = set()
 
     entries = [e for e in root.iter() if _localname(getattr(e, "tag", "")).lower() == str(entry_tag).lower()]
-    result: Dict[str, Dict[str, Any]] = {}
+    result_ifc: Dict[str, Dict[str, Any]] = {}
+    result_pdf: List[Dict[str, Any]] = []
 
     for e in entries:
         name = _find_child_text(e, name_tag)
@@ -66,12 +74,29 @@ def extract_from_xml(xml_path: Path, rules: Dict[str, Any], case_sensitive: bool
         crc = _find_child_text(e, checksum_tag)
         if crc:
             crc = crc.strip().upper()
+        fmt_upper = (fmt or "").strip().upper()
 
-        if filter_format and (fmt or "").strip().upper() != str(filter_format).upper():
-            continue
+        if (not filter_set) or (fmt_upper in filter_set):
+            key = name if case_sensitive else name.lower()
+            if key not in result_ifc:
+                result_ifc[key] = {"crc_hex": crc, "format": fmt}
 
-        key = name if case_sensitive else name.lower()
-        if key not in result:
-            result[key] = {"crc_hex": crc, "format": fmt}
+        for ch in list(e):
+            if _localname(ch.tag).lower() != "signfile":
+                continue
+            s_name = _find_child_text(ch, name_tag)
+            if not s_name:
+                continue
+            s_fmt = _find_child_text(ch, format_tag)
+            s_crc = _find_child_text(ch, checksum_tag)
+            if s_crc:
+                s_crc = s_crc.strip().upper()
+            s_fmt_upper = (s_fmt or "").strip().upper()
+            if (not filter_set) or (s_fmt_upper in filter_set):
+                result_pdf.append({
+                    "name": s_name if case_sensitive else s_name.lower(),
+                    "format": s_fmt,
+                    "crc_hex": s_crc,
+                })
 
-    return result
+    return result_ifc, result_pdf

--- a/rules.yaml
+++ b/rules.yaml
@@ -3,4 +3,6 @@ entry_tag: ModelFile
 name_tag: FileName
 checksum_tag: FileChecksum
 format_tag: FileFormat
-filter_format: IFC
+filter_format:
+  - IFC
+  - PDF


### PR DESCRIPTION
## Summary
- parse `<SignFile>` nodes alongside `<ModelFile>` to extract PDF names, formats and checksums
- return a separate list of PDF records from `extract_from_xml`
- allow specifying PDF in `filter_format` via updated rules config

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4778b6e14832f8b1649efb80f43ed