### PR TITLE
Add PDF pair validation against XML

### DIFF
--- a/main_cli.py
+++ b/main_cli.py
@@ -9,10 +9,13 @@ from pathlib import Path
 import argparse
 import logging
 
-from pkg.xml_reader import read_rules, extract_from_xml
+from pkg.xml_reader import read_rules, extract_from_xml, extract_iul_pdf_pairs
 from pkg.scanner import collect_ifc_files, collect_pdf_files
 from pkg.report_builder import build_report
 from pkg.xlsx_writer import write_xlsx
+
+from pkg.report_builder_pdf_pairs import build_report_pdf_pairs
+from pkg.xlsx_writer_pdf_pairs import write_xlsx_pdf_pairs
 
 from pkg.iul_reader import extract_iul_entries, PdfReader  # type: ignore
 from pkg.report_builder_iul import build_report_iul
@@ -28,10 +31,13 @@ def main():
     ap.add_argument("--check-xml", action="store_true", help="Выполнить проверку XML↔IFC")
     ap.add_argument("--xml", type=Path, help="Путь к XML с перечнем IFC")
 
-    # IUL
+    # IUL ↔ IFC
     ap.add_argument("--check-iul", action="store_true", help="Выполнить проверку ИУЛ(PDF)↔IFC")
-    ap.add_argument("--iul", type=Path, nargs="*", help="Пути к ИУЛ (PDF). Можно несколько")
-    ap.add_argument("--iul-dir", type=Path, help="Папка с ИУЛ (PDF)")
+
+    # PDF pairs
+    ap.add_argument("--check-pdf-pairs", action="store_true", help="Выполнить проверку ИУЛ PDF↔PDF из XML")
+    ap.add_argument("--iul", type=Path, nargs="*", help="Пути к PDF. Можно несколько")
+    ap.add_argument("--iul-dir", type=Path, help="Папка с PDF")
     ap.add_argument("--recursive-pdf", action="store_true", help="Рекурсивно сканировать подпапки (PDF)")
     ap.add_argument("--pdf-name-strict", action="store_true", help="Строгое правило имени PDF (…_УЛ.pdf)")
 
@@ -41,15 +47,22 @@ def main():
     args = ap.parse_args()
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, format="%(levelname)s: %(message)s")
 
-    if not (args.check_xml or args.check_iul):
+    if not (args.check_xml or args.check_iul or args.check_pdf_pairs):
         args.check_xml = True
         args.check_iul = True
+        args.check_pdf_pairs = True
 
     if not args.ifc_dir.exists() or not args.ifc_dir.is_dir():
         logging.error("Папка с IFC не найдена/не является папкой: %s", args.ifc_dir); return 2
     ifc_files = collect_ifc_files(args.ifc_dir, recursive=args.recursive_ifc)
     if not ifc_files:
         logging.error("В папке не найдено файлов *.ifc"); return 2
+
+    pdfs: list[Path] = []
+    if args.iul:
+        pdfs.extend(args.iul)
+    if args.iul_dir and args.iul_dir.exists():
+        pdfs.extend(collect_pdf_files(args.iul_dir, recursive=args.recursive_pdf))
 
     # XML
     if args.check_xml:
@@ -66,11 +79,6 @@ def main():
 
     # IUL
     if args.check_iul:
-        pdfs: list[Path] = []
-        if args.iul:
-            pdfs.extend(args.iul)
-        if args.iul_dir and args.iul_dir.exists():
-            pdfs.extend(collect_pdf_files(args.iul_dir, recursive=args.recursive_pdf))
         if not pdfs:
             logging.error("Указана проверка ИУЛ, но PDF не заданы/не найдены."); return 2
         if PdfReader is None:
@@ -86,6 +94,19 @@ def main():
         rows_iul = build_report_iul(iul_map, ifc_files, strict_pdf_name=bool(args.pdf_name_strict))
         exit_iul, stats_iul = write_xlsx_iul(rows_iul, out_iul)
         logging.info("Готово (IUL). Отчёт: %s | Итоги: %s", out_iul, stats_iul)
+
+    if args.check_pdf_pairs:
+        if not args.xml or not args.xml.exists():
+            logging.error("Указана проверка PDF-пар, но XML не задан или не найден."); return 2
+        if not pdfs:
+            logging.error("Указана проверка PDF-пар, но PDF не заданы/не найдены."); return 2
+        out_pairs = (args.out or args.xml.with_name("pdf_pair_report.xlsx"))
+        if out_pairs.exists() and not args.force:
+            logging.error("Файл отчёта (PDF пары) уже существует: %s. Запустите с --force для перезаписи.", out_pairs); return 2
+        pairs = extract_iul_pdf_pairs(args.xml)
+        rows_pairs = build_report_pdf_pairs(pairs, pdfs)
+        exit_pairs, stats_pairs = write_xlsx_pdf_pairs(rows_pairs, out_pairs)
+        logging.info("Готово (PDF пары). Отчёт: %s | Итоги: %s", out_pairs, stats_pairs)
 
     return 0
 

--- a/pkg/report_builder_pdf_pairs.py
+++ b/pkg/report_builder_pdf_pairs.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .crc import compute_crc32
+
+def build_report_pdf_pairs(pairs: Dict[str, Dict[str, Optional[str]]], pdf_files: List[Path]) -> List[Dict]:
+    rows: List[Dict] = []
+    index = {p.name: p for p in pdf_files}
+
+    for iul_name, meta in pairs.items():
+        base_name = meta.get("base_name")
+        iul_crc = (meta.get("iul_crc") or "").upper() or None
+        base_crc = (meta.get("base_crc") or "").upper() or None
+
+        iul_path = index.get(iul_name)
+        base_path = index.get(base_name) if base_name else None
+
+        status: List[str] = []
+        details: List[str] = []
+
+        if not iul_path:
+            status.append("MISSING_IUL")
+            details.append("Не найден PDF ИУЛ")
+        if not base_path:
+            status.append("MISSING_BASE")
+            details.append("Не найден PDF осн.")
+
+        if iul_path and iul_crc:
+            actual_iul = f"{compute_crc32(iul_path):08X}"
+            if actual_iul != iul_crc:
+                status.append("CRC_MISMATCH")
+                details.append(f"CRC ИУЛ: XML={iul_crc}, факт={actual_iul}")
+        elif iul_path and not iul_crc:
+            actual_iul = f"{compute_crc32(iul_path):08X}"
+            status.append("CRC_MISMATCH")
+            details.append(f"CRC ИУЛ отсутствует в XML, факт={actual_iul}")
+
+        if base_path and base_crc:
+            actual_base = f"{compute_crc32(base_path):08X}"
+            if actual_base != base_crc:
+                if "CRC_MISMATCH" not in status:
+                    status.append("CRC_MISMATCH")
+                details.append(f"CRC осн.: XML={base_crc}, факт={actual_base}")
+        elif base_path and not base_crc:
+            actual_base = f"{compute_crc32(base_path):08X}"
+            if "CRC_MISMATCH" not in status:
+                status.append("CRC_MISMATCH")
+            details.append(f"CRC осн. отсутствует в XML, факт={actual_base}")
+
+        if not status:
+            status.append("OK")
+
+        rows.append({
+            "PDF ИУЛ": iul_name,
+            "CRC ИУЛ": iul_crc,
+            "PDF осн.": base_name,
+            "CRC осн.": base_crc,
+            "Статус": ";".join(status),
+            "Подробности": "; ".join(details) if details else None,
+        })
+
+    return rows
+

--- a/pkg/xlsx_writer_pdf_pairs.py
+++ b/pkg/xlsx_writer_pdf_pairs.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+from pathlib import Path
+from typing import List, Dict
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill, Border, Side
+from openpyxl.utils import get_column_letter
+from openpyxl.formatting.rule import CellIsRule
+
+GREEN = PatternFill(start_color="E7F7E7", end_color="E7F7E7", fill_type="solid")
+RED = PatternFill(start_color="FFE5E5", end_color="FFE5E5", fill_type="solid")
+GRAY = PatternFill(start_color="F2F2F2", end_color="F2F2F2", fill_type="solid")
+
+HEADERS = [
+    "PDF ИУЛ",
+    "CRC ИУЛ",
+    "PDF осн.",
+    "CRC осн.",
+    "Статус",
+    "Подробности",
+]
+
+def _autosize(ws):
+    max_width = {}
+    for row in ws.iter_rows(values_only=True):
+        for idx, val in enumerate(row, start=1):
+            s = "" if val is None else str(val)
+            width = max(3, min(120, int(len(s) * 1.1) + 2))
+            if idx not in max_width or width > max_width[idx]:
+                max_width[idx] = width
+    for idx, w in max_width.items():
+        ws.column_dimensions[get_column_letter(idx)].width = w
+
+def _borders(ws):
+    thin = Side(border_style="thin", color="D0D0D0")
+    border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in ws.iter_rows(min_row=1, max_row=ws.max_row, min_col=1, max_col=ws.max_column):
+        for cell in row:
+            cell.border = border
+
+def _style(ws):
+    for c in ws[1]:
+        c.font = Font(bold=True)
+        c.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+        c.fill = GRAY
+
+    left_cols = (1,3,6)
+    for row in ws.iter_rows(min_row=2):
+        for cell in row:
+            if cell.column in left_cols:
+                cell.alignment = Alignment(horizontal="left", vertical="top", wrap_text=True)
+            else:
+                cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+
+    ws.auto_filter.ref = ws.dimensions
+    ws.freeze_panes = "A2"
+
+    ws.conditional_formatting.add(f"E2:E{ws.max_row}", CellIsRule(operator='equal', formula=['"OK"'], fill=GREEN))
+    ws.conditional_formatting.add(f"E2:E{ws.max_row}", CellIsRule(operator='notEqual', formula=['"OK"'], fill=RED))
+
+def write_xlsx_pdf_pairs(rows: List[Dict], out_path: Path) -> tuple[int, dict]:
+    wb = Workbook()
+    ws = wb.active; ws.title = "PDF Pairs"
+
+    ws.append(HEADERS)
+    for r in rows:
+        ws.append([
+            r.get("PDF ИУЛ"),
+            r.get("CRC ИУЛ"),
+            r.get("PDF осн."),
+            r.get("CRC осн."),
+            r.get("Статус"),
+            r.get("Подробности"),
+        ])
+
+    _style(ws)
+    _autosize(ws)
+    _borders(ws)
+
+    sm = wb.create_sheet("Summary")
+    total = len(rows)
+    ok = sum(1 for r in rows if r["Статус"] == "OK")
+    errors = total - ok
+    sm.append(["Метрика", "Значение"])
+    sm.append(["Всего строк", total])
+    sm.append(["OK", ok])
+    sm.append(["Ошибки (все не-OK)", errors])
+    sm.auto_filter.ref = sm.dimensions
+    sm.freeze_panes = "A2"
+    for c in sm[1]:
+        c.font = Font(bold=True)
+        c.alignment = Alignment(horizontal="center", vertical="center")
+        c.fill = GRAY
+
+    maxw = {}
+    for row in sm.iter_rows(values_only=True):
+        for idx, val in enumerate(row, start=1):
+            s = "" if val is None else str(val)
+            w = max(3, min(80, int(len(s)*1.1)+2))
+            if idx not in maxw or w>maxw[idx]:
+                maxw[idx]=w
+    for idx, w in maxw.items():
+        sm.column_dimensions[get_column_letter(idx)].width = w
+    thin = Side(border_style="thin", color="D0D0D0")
+    border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in sm.iter_rows(min_row=1, max_row=sm.max_row, min_col=1, max_col=sm.max_column):
+        for cell in row:
+            cell.border = border
+
+    wb.save(out_path)
+    exit_code = 0 if errors==0 else 1
+    return exit_code, {"total": total, "ok": ok, "errors": errors}
+


### PR DESCRIPTION
## Summary
- parse IUL PDF ↔ base PDF pair info from XML
- validate PDF pairs against files and CRC and output pdf_pair_report.xlsx
- expose new checks via `--check-pdf-pairs` flag and GUI checkbox

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4778dc4c4832f906f6bf912c0fedf