### PR TITLE
Handle signature files optionally in XML extraction

### DIFF
--- a/main_cli.py
+++ b/main_cli.py
@@ -69,7 +69,9 @@ def main():
         if out_xml.exists() and not args.force:
             logging.error("Файл отчёта (XML) уже существует: %s. Запустите с --force для перезаписи.", out_xml); return 2
         rules = read_rules(Path(__file__).with_name("rules.yaml"))
-        xml_map, xml_pdf = extract_from_xml(args.xml, rules, case_sensitive=True)
+        xml_map, xml_pdf = extract_from_xml(
+            args.xml, rules, case_sensitive=True, include_sign_files=True
+        )
         rows_xml = build_report(xml_map, ifc_files, case_sensitive=True)
         exit_xml, stats_xml = write_xlsx(rows_xml, out_xml)
         logging.info("Готово (XML). Отчёт: %s | Итоги: %s | Подписей PDF: %s", out_xml, stats_xml, len(xml_pdf))

--- a/main_gui.py
+++ b/main_gui.py
@@ -263,7 +263,9 @@ class App(tk.Tk):
                     else:
                         self._log(f"{EMOJI['xml']} Чтение XML...")
                         rules = read_rules(Path(__file__).with_name("rules.yaml"))
-                        xml_map, xml_pdf = extract_from_xml(xml, rules, case_sensitive=True)
+                        xml_map, xml_pdf = extract_from_xml(
+                            xml, rules, case_sensitive=True, include_sign_files=True
+                        )
                         self._log(f"    Записей IFC в XML: {len(xml_map)} | Подписей PDF: {len(xml_pdf)}")
 
                         self._log(f"{EMOJI['search']} Сверка по XML...")

--- a/pkg/xml_reader.py
+++ b/pkg/xml_reader.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Dict, Any, Optional, List
 import xml.etree.ElementTree as ET
 
 try:
@@ -43,7 +43,21 @@ def _find_child_text(elem: ET.Element, wanted: str) -> Optional[str]:
             return txt if txt else None
     return None
 
-def extract_from_xml(xml_path: Path, rules: Dict[str, Any], case_sensitive: bool=True) -> Tuple[Dict[str, Dict[str, Any]], List[Dict[str, Any]]]:
+def extract_from_xml(
+    xml_path: Path,
+    rules: Dict[str, Any],
+    case_sensitive: bool = True,
+    include_sign_files: bool = False,
+) -> Any:
+    """Parse ``xml_path`` and extract file information.
+
+    By default only data about model files are returned.  If ``include_sign_files``
+    is ``True`` the function will also look for nested ``SignFile`` entries and
+    return a tuple ``(model_map, sign_files)`` where ``sign_files`` is a list of
+    dictionaries with information about every signature file.  This keeps the
+    simple dictionary return type that the public API historically exposed while
+    still allowing the CLI/GUI tools to access the additional data.
+    """
     if not xml_path.exists():
         raise FileNotFoundError(f"XML не найден: {xml_path}")
     tree = ET.parse(str(xml_path))
@@ -99,4 +113,6 @@ def extract_from_xml(xml_path: Path, rules: Dict[str, Any], case_sensitive: bool
                     "crc_hex": s_crc,
                 })
 
-    return result_ifc, result_pdf
+    if include_sign_files:
+        return result_ifc, result_pdf
+    return result_ifc


### PR DESCRIPTION
## Summary
- Add optional `include_sign_files` flag to `extract_from_xml`
- Update CLI and GUI to request sign file details explicitly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c49495f6ec832faf8482a346b044dc