### PR TITLE
Improve GUI layout and IUL PDF checks

### DIFF
--- a/pkg/xlsx_writer_combined.py
+++ b/pkg/xlsx_writer_combined.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Optional
 from openpyxl import Workbook
 
 from .xlsx_writer import HEADERS as XML_HEADERS
-from .xlsx_writer_iul import HEADERS as IUL_HEADERS
+from .xlsx_writer_iul import get_headers as get_iul_headers
 from .xlsx_writer_pdf_xml import HEADERS as PDF_XML_HEADERS
 from .xlsx_utils import autosize, apply_borders, style_sheet, add_summary_sheet
 
@@ -43,6 +43,7 @@ def write_combined_xlsx(
     iul_rows: Optional[List[Dict]],
     pdf_xml_rows: Optional[List[Dict]],
     out_path: Path,
+    include_pdf_name_col: bool = False,
 ) -> Dict[str, Dict[str, int]]:
     """Write selected reports to a single XLSX workbook.
 
@@ -65,14 +66,23 @@ def write_combined_xlsx(
         )
 
     if iul_rows:
+        headers = get_iul_headers(include_pdf_name_col)
+        if include_pdf_name_col:
+            left_cols = (1, 2, 3, 6, 7, 16, 17)
+            yes_no_cols = ("J", "K", "L", "M", "N")
+            status_col = "O"
+        else:
+            left_cols = (1, 2, 3, 6, 7, 15, 16)
+            yes_no_cols = ("J", "K", "L", "M")
+            status_col = "N"
         stats["iul"] = _add_sheet(
             wb,
             "ИУЛ - IFC",
-            IUL_HEADERS,
+            headers,
             iul_rows,
-            left_cols=(1,2,3,6,7,16,17),
-            yes_no_cols=("J","K","L","M","N"),
-            status_col="O",
+            left_cols=left_cols,
+            yes_no_cols=yes_no_cols,
+            status_col=status_col,
             summary_title="Итого ИУЛ",
         )
 

--- a/pkg/xlsx_writer_iul.py
+++ b/pkg/xlsx_writer_iul.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 from openpyxl import Workbook
 from .xlsx_utils import autosize, apply_borders, style_sheet, add_summary_sheet
 
-HEADERS = [
+BASE_HEADERS = [
     "Имя файла",
     "Имя PDF",
     "Файл из ИУЛ",
@@ -20,19 +20,34 @@ HEADERS = [
     "CRC совпадает",
     "Дата/время совпадает",
     "Размер совпадает",
-    "Имя PDF соответствует правилу",
     "Статус",
     "Подробности",
     "Рекомендации",
 ]
 
-def write_xlsx_iul(rows: List[Dict], out_path: Path) -> tuple[int, dict]:
-    wb = Workbook()
-    ws = wb.active; ws.title = "ИУЛ - IFC"
+PDF_NAME_COL = "Имя PDF соответствует шаблону"
 
-    ws.append(HEADERS)
+
+def get_headers(include_pdf_name_col: bool) -> List[str]:
+    headers = BASE_HEADERS.copy()
+    if include_pdf_name_col:
+        headers.insert(13, PDF_NAME_COL)
+    return headers
+
+
+def write_xlsx_iul(
+    rows: List[Dict],
+    out_path: Path,
+    include_pdf_name_col: bool = True,
+) -> tuple[int, dict]:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "ИУЛ - IFC"
+
+    headers = get_headers(include_pdf_name_col)
+    ws.append(headers)
     for r in rows:
-        ws.append([
+        row_data = [
             r.get("Имя файла"),
             r.get("Имя PDF"),
             r.get("Файл из ИУЛ"),
@@ -46,17 +61,30 @@ def write_xlsx_iul(rows: List[Dict], out_path: Path) -> tuple[int, dict]:
             r.get("CRC совпадает"),
             r.get("Дата/время совпадает"),
             r.get("Размер совпадает"),
-            r.get("Имя PDF соответствует правилу"),
+        ]
+        if include_pdf_name_col:
+            row_data.append(r.get(PDF_NAME_COL))
+        row_data.extend([
             r.get("Статус"),
             r.get("Подробности"),
             r.get("recommendation"),
         ])
+        ws.append(row_data)
+
+    if include_pdf_name_col:
+        yes_no_cols = ("J", "K", "L", "M", "N")
+        status_col = "O"
+        left_cols = (1, 2, 3, 6, 7, 16, 17)
+    else:
+        yes_no_cols = ("J", "K", "L", "M")
+        status_col = "N"
+        left_cols = (1, 2, 3, 6, 7, 15, 16)
 
     style_sheet(
         ws,
-        left_cols=(1,2,3,6,7,16,17),
-        yes_no_cols=("J","K","L","M","N"),
-        status_col="O",
+        left_cols=left_cols,
+        yes_no_cols=yes_no_cols,
+        status_col=status_col,
     )
     autosize(ws)
     apply_borders(ws)

--- a/tests/test_report_builder_iul.py
+++ b/tests/test_report_builder_iul.py
@@ -32,13 +32,13 @@ def test_build_report_iul_scenarios(tmp_path):
     crc_name, dt_name, size_name = info(name_mismatch_file)
 
     iul_map = {
-        'good.ifc': IulEntry('good.ifc', crc_good, dt_good, size_good, 'ctx', 'goodИУЛ.pdf'),
-        'crc_bad.ifc': IulEntry('crc_bad.ifc', 'FFFFFFFF', dt_crc, size_crc, 'ctx', 'crc_badИУЛ.pdf'),
-        'size_bad.ifc': IulEntry('size_bad.ifc', crc_size, dt_size, size_size + 1, 'ctx', 'size_badИУЛ.pdf'),
-        'dt_bad.ifc': IulEntry('dt_bad.ifc', crc_dt, '01.01.2000 00:00', size_dt, 'ctx', 'dt_badИУЛ.pdf'),
+        'good.ifc': IulEntry('good.ifc', crc_good, dt_good, size_good, 'ctx', 'good_ИУЛ.pdf'),
+        'crc_bad.ifc': IulEntry('crc_bad.ifc', 'FFFFFFFF', dt_crc, size_crc, 'ctx', 'crc_bad_ИУЛ.pdf'),
+        'size_bad.ifc': IulEntry('size_bad.ifc', crc_size, dt_size, size_size + 1, 'ctx', 'size_bad_ИУЛ.pdf'),
+        'dt_bad.ifc': IulEntry('dt_bad.ifc', crc_dt, '01.01.2000 00:00', size_dt, 'ctx', 'dt_bad_ИУЛ.pdf'),
         'pdf_bad.ifc': IulEntry('pdf_bad.ifc', crc_pdf, dt_pdf, size_pdf, 'ctx', 'pdf_bad.pdf'),
-        'other.ifc': IulEntry('other.ifc', crc_name, dt_name, size_name, 'ctx', 'name_mismatchИУЛ.pdf'),
-        'missing.ifc': IulEntry('missing.ifc', 'ABCDEF12', '01.01.2024 00:00', 123, 'ctx', 'missingИУЛ.pdf'),
+        'other.ifc': IulEntry('other.ifc', crc_name, dt_name, size_name, 'ctx', 'name_mismatch_ИУЛ.pdf'),
+        'missing.ifc': IulEntry('missing.ifc', 'ABCDEF12', '01.01.2024 00:00', 123, 'ctx', 'missing_ИУЛ.pdf'),
     }
 
     rows = build_report_iul(iul_map, [good, crc_bad, size_bad, dt_bad, pdf_bad, name_mismatch_file, extra])


### PR DESCRIPTION
## Summary
- enhance GUI: move report opening option, add recursive toggles, clarify strict PDF name
- log each IUL entry to keep progress bar active
- rename/conditionally include PDF-name column and tighten IUL PDF name validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c527ce83ec832fb7bfdf9dedd8da49