### PR TITLE
Ensure XML CRC shows and missing IUL PDFs flagged

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -19,8 +19,8 @@ from pkg.report_builder_iul import build_report_iul
 from pkg.xlsx_writer_combined import write_combined_xlsx
 
 APP_TITLE = "IFC CRC Checker — GUI"
-# slightly wider to fit buttons and locked size
-APP_MIN_W, APP_MIN_H = 1080, 800
+# slightly wider for better layout
+APP_MIN_W, APP_MIN_H = 1160, 800
 
 EMOJI = {
     "xml": "🧾",

--- a/pkg/report_builder.py
+++ b/pkg/report_builder.py
@@ -44,6 +44,7 @@ def build_report(xml_map: Dict[str, dict], ifc_files: List[Path], case_sensitive
 
         name_match = None
         crc_match = None
+        xml_crc_from_xml = None
         status: List[str] = []
         details: List[str] = []
         xml_name_from_xml = base if meta else None
@@ -54,6 +55,8 @@ def build_report(xml_map: Dict[str, dict], ifc_files: List[Path], case_sensitive
             if len(hits) == 1:
                 xml_name = hits[0]
                 xml_name_from_xml = xml_name
+                meta_hit = xml_map.get(xml_name if case_sensitive else xml_name.lower())
+                xml_crc_from_xml = ((meta_hit.get("crc_hex") or "").upper() if meta_hit else None)
                 used_xml.add(xml_name if case_sensitive else xml_name.lower())
                 name_match = (xml_name == base)
                 if not name_match:
@@ -69,12 +72,12 @@ def build_report(xml_map: Dict[str, dict], ifc_files: List[Path], case_sensitive
         else:
             used_xml.add(key)
             name_match = True
-            xml_crc = (meta.get("crc_hex") or "").upper() or None
-            if xml_crc:
-                crc_match = (xml_crc == actual_crc_hex)
+            xml_crc_from_xml = (meta.get("crc_hex") or "").upper() or None
+            if xml_crc_from_xml:
+                crc_match = (xml_crc_from_xml == actual_crc_hex)
                 if not crc_match:
                     status.append("CRC_MISMATCH")
-                    details.append(f"CRC-32 не совпадает: XML={xml_crc}, IFC={actual_crc_hex}")
+                    details.append(f"CRC-32 не совпадает: XML={xml_crc_from_xml}, IFC={actual_crc_hex}")
             else:
                 details.append("В XML отсутствует CRC-32")
 
@@ -84,7 +87,7 @@ def build_report(xml_map: Dict[str, dict], ifc_files: List[Path], case_sensitive
         rows.append({
             "Имя файла": base,
             "Файл из XML": xml_name_from_xml,
-            "CRC-32 XML": ((meta.get('crc_hex') or '').upper() if meta else None),
+            "CRC-32 XML": xml_crc_from_xml,
             "CRC-32 IFC": actual_crc_hex,
             "Имя совпадает": tri(name_match),
             "CRC совпадает": tri(crc_match),

--- a/pkg/report_builder_iul.py
+++ b/pkg/report_builder_iul.py
@@ -119,7 +119,7 @@ def build_report_iul(
         expected_pdf_name = f"{Path(base).stem}_УЛ.pdf"
         row = {
             "Имя файла": base,
-            "Имя PDF": (e.source_pdf if e else expected_pdf_name),
+            "Имя PDF": (e.source_pdf if e else "Не найден"),
             "Файл из ИУЛ": (e.basename if e else None),
             "CRC-32 ИУЛ": (e.crc_hex.upper() if (e and e.crc_hex) else None),
             "CRC-32 IFC": actual_crc_hex,

--- a/tests/test_report_builder.py
+++ b/tests/test_report_builder.py
@@ -33,3 +33,6 @@ def test_build_report_scenarios(tmp_path):
     assert status['name_mismatch.ifc'] == 'NAME_MISMATCH'
     assert status['extra.ifc'] == 'ERROR_IFC_EXTRA'
     assert status['missing.ifc'] == 'ERROR_XML_EXTRA'
+
+    row_nm = next(r for r in rows if r['Имя файла'] == 'name_mismatch.ifc')
+    assert row_nm['CRC-32 XML'] == crc_name

--- a/tests/test_report_builder_iul.py
+++ b/tests/test_report_builder_iul.py
@@ -54,4 +54,4 @@ def test_build_report_iul_scenarios(tmp_path):
     assert status['missing.ifc'] == 'ERROR_IUL_EXTRA'
 
     row_extra = next(r for r in rows if r.get('Имя файла') == 'extra.ifc')
-    assert row_extra['Имя PDF'] == 'extra_УЛ.pdf'
+    assert row_extra['Имя PDF'] == 'Не найден'


### PR DESCRIPTION
## Summary
- populate CRC-32 XML column when IFC is matched only by checksum
- flag absent IUL PDFs with "Не найден" in reports
- widen GUI window for improved layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c53d1503e8832fad63719091ae91eb