### PR TITLE
Add build script to generate Windows executables

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,6 +28,11 @@ IFC CRC Checker — полная сборка
     # только ИУЛ↔IFC (папка с PDF, рекурсивно, строгая проверка имени PDF)
     py main_cli.py --check-iul --ifc-dir "C:\IFC" --recursive-ifc --iul-dir "C:\IUL" --recursive-pdf --pdf-name-strict --force
 
+Сборка .exe (Windows, PyInstaller)
+    py -m pip install -r requirements.txt -r requirements-dev.txt
+    py build_exe.py
+Экзешники появятся в папке dist/.
+
 Примечание по VS Code
 - Если запускаете через «Play», убедитесь, что рабочая директория — это папка ifc_crc_checker_mod.
   Либо используйте запуск из терминала:

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,51 @@
+"""Build Windows executables using PyInstaller.
+
+This script creates two standalone executables for the CLI and GUI entry
+points. PyInstaller must be installed in the active environment.
+Run on Windows:
+    python build_exe.py
+The built binaries will appear in the ``dist`` directory.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import PyInstaller.__main__  # type: ignore
+
+ROOT = Path(__file__).resolve().parent
+
+# Data files required at runtime
+DATA_FILES = ["rules.yaml", "INSTRUCTION.md"]
+
+
+def _build(target: str, *, windowed: bool, name: str) -> None:
+    """Run PyInstaller for a single target.
+
+    Args:
+        target: The entry-point script relative to the project root.
+        windowed: Whether to build a GUI application without console.
+    """
+
+    opts: list[str] = [
+        str(ROOT / target),
+        "--onefile",
+        "--name",
+        name,
+    ]
+    if windowed:
+        opts.append("--windowed")
+
+    sep = os.pathsep  # ";" on Windows, ":" on POSIX
+    for f in DATA_FILES:
+        opts += ["--add-data", f"{ROOT / f}{sep}." ]
+
+    PyInstaller.__main__.run(opts)
+
+
+def main() -> None:
+    _build("main_cli.py", windowed=False, name="xmlchecks_cli")
+    _build("main_gui.py", windowed=True, name="xmlchecks_gui")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest>=8.0.0
+pyinstaller>=6.3


### PR DESCRIPTION
## Summary
- add `build_exe.py` to generate CLI/GUI `.exe` via PyInstaller
- document building executables in README
- include PyInstaller in dev requirements

## Testing
- `python -m py_compile build_exe.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c543ea9ddc832f96b29070906181a6