### PR TITLE
Handle CLI diagnostics without arguments

### DIFF
--- a/diagnostics_iul.py
+++ b/diagnostics_iul.py
@@ -179,10 +179,10 @@ def _analyze_pdf(pdf_path: Path) -> None:
         print("OCR не вернул ни одной непустой строки")
 
 
-def _parse_arguments(argv: Iterable[str]) -> Path:
+def _parse_arguments(argv: Iterable[str]) -> Optional[Path]:
     args = list(argv)
     if not args:
-        return Path()
+        return None
     return Path(args[0]).expanduser()
 
 
@@ -203,7 +203,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     _list_tesseract_languages(exe_path)
     _check_required_modules()
 
-    if pdf_path:
+    if pdf_path is not None:
         _analyze_pdf(pdf_path)
     else:
         _print_heading("Анализ PDF не выполнялся")

--- a/tests/test_diagnostics_iul.py
+++ b/tests/test_diagnostics_iul.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from xmlchecks import diagnostics_iul
+
+
+def test_main_without_arguments(monkeypatch, capsys):
+    calls = []
+
+    monkeypatch.setattr(diagnostics_iul, "_print_heading", lambda *_: None)
+    monkeypatch.setattr(diagnostics_iul, "_diagnose_pkg_import", lambda: None)
+    monkeypatch.setattr(diagnostics_iul, "_check_tesseract_configuration", lambda *_: Path())
+    monkeypatch.setattr(diagnostics_iul, "_list_tesseract_languages", lambda *_: None)
+    monkeypatch.setattr(diagnostics_iul, "_check_required_modules", lambda: None)
+    monkeypatch.setattr(diagnostics_iul, "_import_module", lambda *_: None)
+
+    def fake_analyze(path):
+        calls.append(path)
+
+    monkeypatch.setattr(diagnostics_iul, "_analyze_pdf", fake_analyze)
+    monkeypatch.setattr(diagnostics_iul.sys, "argv", ["diagnostics_iul.py"])
+
+    diagnostics_iul.main()
+
+    captured = capsys.readouterr()
+    assert calls == []
+    assert "Передайте путь к PDF" in captured.out


### PR DESCRIPTION
## Summary
- обновил diagnostics_iul._parse_arguments для возврата Optional[Path] и корректного поведения при отсутствии аргументов
- скорректировал main, чтобы анализ запускался только при наличии пути
- добавил тест, проверяющий сценарий запуска без аргументов

## Testing
- pytest tests/test_diagnostics_iul.py

------
https://chatgpt.com/codex/tasks/task_e_68cfebe09428832fb3457fe5190042c8