### PR TITLE
Добавить утилиту для проверки OCR в PDF

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -34,6 +34,35 @@ IFC CRC Checker — полная сборка
     # только ИУЛ↔IFC (папка с PDF, рекурсивно, строгая проверка имени PDF)
     py main_cli.py --check-iul --ifc-dir "C:\IFC" --recursive-ifc --iul-dir "C:\IUL" --recursive-pdf --pdf-name-strict --force
 
+Проверка распознавания текста в PDF (отладочный скрипт)
+------------------------------------------------------
+Скрипт `pdf_ocr_debug.py` помогает понять, распознаётся ли текст в конкретном PDF
+и нужен ли OCR. Запустите его из корня проекта и передайте один или несколько путей
+к PDF-файлам:
+
+```
+py pdf_ocr_debug.py "C:\путь\к\файлу.pdf"
+```
+
+Если Python настроен через `python`, используйте:
+
+```
+python pdf_ocr_debug.py /home/user/documents/sample.pdf
+```
+
+Можно указать несколько файлов разом:
+
+```
+python pdf_ocr_debug.py file1.pdf file2.pdf
+```
+
+Полезные опции:
+
+- `--no-pypdf2` — отключить извлечение текста через PyPDF2.
+- `--no-ocr` — отключить OCR (PyMuPDF + pytesseract).
+- `--preview-lines N` — сколько строк показать в превью (по умолчанию 40).
+- `--show-raw` — вывести «сырой» текст без нормализации.
+
 Сборка .exe (Windows, PyInstaller)
     py -m pip install -r requirements.txt -r requirements-dev.txt
     py build_exe.py

--- a/pdf_ocr_debug.py
+++ b/pdf_ocr_debug.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Утилита для проверки распознавания текста в PDF.
+
+Скрипт извлекает текст из PDF двумя способами: через PyPDF2 и через OCR
+(PyMuPDF + pytesseract). Полученный текст выводится в консоль, что позволяет
+оперативно понять, сработал ли OCR и какой результат он дал.
+
+Запуск из корня проекта (можно указать несколько файлов):
+
+```
+python pdf_ocr_debug.py path/to/file1.pdf path/to/file2.pdf
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+from pkg.iul_reader import extract_pdf_text_debug
+
+
+def _print_preview(text: str, *, max_lines: int) -> None:
+    """Выводит первые ``max_lines`` строк текста."""
+
+    if not text:
+        return
+
+    lines = text.splitlines()
+    preview = lines[:max_lines]
+    for ln in preview:
+        print(ln)
+    if len(lines) > max_lines:
+        print("...")
+
+
+def _print_source_result(name: str, payload: Dict[str, str], *, max_lines: int, show_raw: bool) -> None:
+    raw_text = payload.get("raw", "")
+    normalized = payload.get("normalized", "")
+    chars_raw = len(raw_text)
+    chars_normalized = len(normalized)
+
+    print(f"  [{name}] символов (raw/normalized): {chars_raw}/{chars_normalized}")
+
+    text_to_show = raw_text if show_raw else normalized
+    _print_preview(text_to_show, max_lines=max_lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Проверка распознавания текста в PDF. Можно сравнить результат PyPDF2"
+            " и OCR, чтобы понять, нужен ли дополнительный тюнинг."
+        )
+    )
+    parser.add_argument("pdf", nargs="+", type=Path, help="Пути к PDF-файлам для проверки")
+    parser.add_argument("--dpi", type=int, default=300, help="DPI для OCR (по умолчанию 300)")
+    parser.add_argument(
+        "--no-pypdf2",
+        action="store_true",
+        help="Не использовать извлечение текста через PyPDF2",
+    )
+    parser.add_argument(
+        "--no-ocr",
+        action="store_true",
+        help="Не выполнять OCR (PyMuPDF + pytesseract)",
+    )
+    parser.add_argument(
+        "--preview-lines",
+        type=int,
+        default=40,
+        help="Сколько строк текста выводить в качестве превью (по умолчанию 40)",
+    )
+    parser.add_argument(
+        "--show-raw",
+        action="store_true",
+        help="Показывать «сырой» текст вместо нормализованного",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.no_pypdf2 and args.no_ocr:
+        parser.error("некуда извлекать текст: отключены и PyPDF2, и OCR")
+
+    status = 0
+    for pdf_path in args.pdf:
+        print(f"=== {pdf_path} ===")
+        if not pdf_path.exists():
+            print("  [ошибка] файл не найден")
+            status = 1
+            continue
+        if not pdf_path.is_file():
+            print("  [ошибка] указан не файл")
+            status = 1
+            continue
+
+        try:
+            payload = extract_pdf_text_debug(
+                pdf_path,
+                dpi=args.dpi,
+                include_pypdf2=not args.no_pypdf2,
+                include_ocr=not args.no_ocr,
+            )
+        except Exception as exc:  # pragma: no cover - диагностическое сообщение
+            print(f"  [ошибка] не удалось обработать PDF: {exc}")
+            status = 1
+            continue
+
+        if not payload:
+            print("  [предупреждение] нет данных для вывода")
+            continue
+
+        for name, data in payload.items():
+            _print_source_result(
+                name,
+                data,
+                max_lines=max(1, args.preview_lines),
+                show_raw=args.show_raw,
+            )
+
+    return status
+
+
+if __name__ == "__main__":  # pragma: no cover - точка входа для CLI
+    raise SystemExit(main())

--- a/pkg/iul_reader.py
+++ b/pkg/iul_reader.py
@@ -136,6 +136,40 @@ def _normalize_text(txt: str) -> str:
     txt = txt.replace("\r", "\n")
     return "\n".join(ln.strip() for ln in txt.splitlines())
 
+
+def extract_pdf_text_debug(
+    pdf_path: Path,
+    *,
+    dpi: int = 300,
+    include_pypdf2: bool = True,
+    include_ocr: bool = True,
+) -> Dict[str, Dict[str, str]]:
+    """Возвращает тексты, полученные разными способами из PDF.
+
+    Функция предназначена для отладки OCR. Она не используется в основной
+    логике, но позволяет получить как «сырой» текст, так и нормализованный
+    вариант для каждого источника (PyPDF2 и/или OCR).
+    """
+
+    results: Dict[str, Dict[str, str]] = {}
+
+    if include_pypdf2:
+        raw_pypdf2 = _extract_text_pypdf2(pdf_path)
+        results["pypdf2"] = {
+            "raw": raw_pypdf2,
+            "normalized": _normalize_text(raw_pypdf2),
+        }
+
+    if include_ocr:
+        raw_ocr = _extract_text_ocr(pdf_path, dpi=dpi)
+        results["ocr"] = {
+            "raw": raw_ocr,
+            "normalized": _normalize_text(raw_ocr),
+        }
+
+    return results
+
+
 def _parse_entries(text: str, pdf_name: str, progress: Optional[Callable[[IulEntry], None]] = None) -> List[IulEntry]:
     lines = [ln for ln in text.splitlines() if ln]
     entries: List[IulEntry] = []


### PR DESCRIPTION
## Summary
- добавил в `iul_reader` вспомогательную функцию для получения текста из PDF разными способами
- создал скрипт `pdf_ocr_debug.py` для ручной проверки результатов PyPDF2 и OCR
- дополнил документацию инструкцией по запуску скрипта с путями к PDF

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfecd17bec832faf97b81206bf819f